### PR TITLE
Ajout des réponses par block et optimisations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ webserv
 .nfs*
 ubuntu_tester
 ubuntu_cgi_tester
+www/heavy.txt

--- a/srcs/class/response.cpp
+++ b/srcs/class/response.cpp
@@ -88,13 +88,13 @@ int Response::send()
 				{
 					std::cout << "Client close remote: " << this->client_socket << std::endl;
 					close(this->client_socket);
+					status = -1;
 					break;
 				}
 
 				memset(buf, 0, MAX_BODY_LENGTH + 2 + 1);
 				length -= transmit_size;
 			}
-			std::cerr << "quit" << std::endl;
 
 			if (in_file.is_open())
 				in_file.close();

--- a/srcs/class/response.cpp
+++ b/srcs/class/response.cpp
@@ -78,8 +78,8 @@ int		Response::send_chunk()
 		if (!this->_in_file.is_open())
 			return -1;
 
-		char buf[MAX_BODY_LENGTH + 2 + 1];
-		memset(buf, 0, MAX_BODY_LENGTH + 2 + 1);
+		char buf[MAX_BODY_LENGTH + 1];
+		memset(buf, 0, MAX_BODY_LENGTH + 1);
 
 		size_t transmit_size = this->get_size_next_chunk();
 		this->_in_file.read(buf, transmit_size);

--- a/srcs/class/response.cpp
+++ b/srcs/class/response.cpp
@@ -79,10 +79,22 @@ int Response::send()
 				in_file.read(buf, transmit_size);
 
 				std::string response_content = intToHex(transmit_size) + "\r\n" + std::string(buf, transmit_size) + "\r\n";
+			
 				status = ::send(this->client_socket, response_content.c_str(), response_content.size(), 0);
+
+				/* with MSG_PEEK, no data will be ride of the socket */
+				char buffer[256];
+				if (recv(this->client_socket, buffer, sizeof(buffer), MSG_PEEK | MSG_DONTWAIT) == 0)
+				{
+					std::cout << "Client close remote: " << this->client_socket << std::endl;
+					close(this->client_socket);
+					break;
+				}
+
 				memset(buf, 0, MAX_BODY_LENGTH + 2 + 1);
 				length -= transmit_size;
 			}
+			std::cerr << "quit" << std::endl;
 
 			if (in_file.is_open())
 				in_file.close();

--- a/srcs/class/response.hpp
+++ b/srcs/class/response.hpp
@@ -28,6 +28,8 @@ class Response
 		std::map<std::string, std::string>		headers;
 		const Request							&req;
 		int										_return_body_type;
+		std::ifstream							_in_file;
+		size_t									_file_len;
 
 		Response( void );
 	public:
@@ -51,7 +53,9 @@ class Response
 		void set_status( int status_code, std::string msg );
 		std::string	load_body( Request &req );
 		std::string & error_body(void);
-		bool isFile(void);
-		int	send(void);
+		bool	isFile(void);
+		int		send(void);
+		int send_chunk(void);
+		size_t get_size_next_chunk();
 		const Webserv_conf &get_conf() const;
 };

--- a/srcs/class/response.hpp
+++ b/srcs/class/response.hpp
@@ -5,10 +5,17 @@
 #include <stdio.h>
 #include <vector>
 
+#include "webserv.hpp"
+
 #include "request.hpp"
 #include "configuration/webserv.hpp"
 #include "errors/http_code.hpp"
 #include "cgi/cgi_manager.hpp"
+
+#define MAX_BODY_LENGTH 1024
+
+#define BODY_TYPE_FILE		1
+#define BODY_TYPE_STRING	2
 
 class Request;
 
@@ -20,6 +27,7 @@ class Response
 		std::string								version;
 		std::map<std::string, std::string>		headers;
 		const Request							&req;
+		int										_return_body_type;
 
 		Response( void );
 	public:
@@ -43,6 +51,7 @@ class Response
 		void set_status( int status_code, std::string msg );
 		std::string	load_body( Request &req );
 		std::string & error_body(void);
+		bool isFile(void);
 		int	send(void);
 		const Webserv_conf &get_conf() const;
 };

--- a/srcs/class/response.hpp
+++ b/srcs/class/response.hpp
@@ -12,7 +12,7 @@
 #include "errors/http_code.hpp"
 #include "cgi/cgi_manager.hpp"
 
-#define MAX_BODY_LENGTH 1024
+#define MAX_BODY_LENGTH 5096
 
 #define BODY_TYPE_FILE		1
 #define BODY_TYPE_STRING	2

--- a/srcs/get_response.cpp
+++ b/srcs/get_response.cpp
@@ -22,8 +22,7 @@ int http_get_response( Request &req, Response &res ) {
 	http_header_server(req, res);
 	res.add_header("Connection", "Keep-Alive");
 	res.add_header("Keep-Alive", "timeout=5, max=10000");
-
 	res.send();
-	
+
 	return 1;
 }

--- a/srcs/get_response.cpp
+++ b/srcs/get_response.cpp
@@ -20,7 +20,8 @@ int http_get_response( Request &req, Response &res ) {
 	/* generic headers */
 	http_header_date(req, res);
 	http_header_server(req, res);
-	res.add_header( "Connection", "keep-alive" );
+	res.add_header("Connection", "Keep-Alive");
+	res.add_header("Keep-Alive", "timeout=5, max=10000");
 
 	res.send();
 	

--- a/srcs/http_header/Data-length.cpp
+++ b/srcs/http_header/Data-length.cpp
@@ -1,8 +1,11 @@
 #include "../webserv.hpp"
 
 int	http_header_content_length( const Request &req, Response &res ) {
-
 	(void) req;
-	res.add_header( "Content-Length", to_string( res.body.size() ));
+	if (res.body.size() > 1024) {
+		res.add_header("Transfer-Encoding", "chunked");
+	} else {
+		res.add_header("Content-Length", to_string(res.body.size()));
+	}
 	return (1);
 }

--- a/srcs/http_header/Data-length.cpp
+++ b/srcs/http_header/Data-length.cpp
@@ -2,7 +2,7 @@
 
 int	http_header_content_length( const Request &req, Response &res ) {
 	(void) req;
-	if (res.body.size() > 1024) {
+	if (res.body.size() > 1024 || res.isFile()) {
 		res.add_header("Transfer-Encoding", "chunked");
 	} else {
 		res.add_header("Content-Length", to_string(res.body.size()));

--- a/srcs/init/server.cpp
+++ b/srcs/init/server.cpp
@@ -54,7 +54,11 @@ void Server::init_connection()
 
 bool    Server::queue_response(Response *res)
 {
-    this->_queue.push(res);
+    if (res->get_size_next_chunk() == MAX_BODY_LENGTH) {
+        this->_queue.push(res);
+    } else {
+        delete res;
+    }
     return true;
 }
 

--- a/srcs/init/server.cpp
+++ b/srcs/init/server.cpp
@@ -40,6 +40,8 @@ int Server::get_poll_fd() const
 void Server::init_connection()
 {
     this->_socket_fd = socket(AF_INET, SOCK_STREAM, 0);
+    bool set_opt = 1;
+    setsockopt(this->_socket_fd, SOL_SOCKET, SO_REUSEADDR, &set_opt, sizeof(int));
 
     this->_bind_port();
 
@@ -72,8 +74,6 @@ void    Server::handle_responses()
         /* with MSG_PEEK, no data will be ride of the socket */
         char buffer[256];
         if (recv(res->client_socket, buffer, sizeof(buffer), MSG_PEEK | MSG_DONTWAIT) == 0) {
-            std::cout << "Client close remote: " << res->client_socket << std::endl;
-            close(res->client_socket);
             delete this->_queue.front();
         } else {
             if (res->send_chunk() > 0) {

--- a/srcs/init/server.hpp
+++ b/srcs/init/server.hpp
@@ -24,7 +24,10 @@
 #include <sys/epoll.h>
 #include <sys/stat.h>
 
+#include <queue>
+
 #include "exception_server_not_listening.hpp"
+#include "class/response.hpp"
 
 #define BACKLOG 10
 
@@ -42,11 +45,15 @@ class Server {
         int     get_socket() const;
         int     get_poll_fd() const;
 
+        bool    queue_response(Response *res);
+        void    handle_responses();
+
     private:
-        short               _port;
-        s_server_addr_in    _addr;
-        int                 _socket_fd;
-        int                 _poll_fd;
+        short                   _port;
+        s_server_addr_in        _addr;
+        int                     _socket_fd;
+        int                     _poll_fd;
+        std::queue<Response *>   _queue;
 
         void     _report(s_server_addr_in *server_addr);
         void     _bind_port();

--- a/srcs/init/server.hpp
+++ b/srcs/init/server.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstring>
+#include <unistd.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -46,4 +49,5 @@ class Server {
         int                 _poll_fd;
 
         void     _report(s_server_addr_in *server_addr);
+        void     _bind_port();
 };

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -39,9 +39,6 @@ void signalHandler(int signum)
 
 int main(int argc, char **argv, char **env)
 {
-	(void)argc;
-	(void)argv;
-
 	if (argc == 2 && argv[1])
 	{
 		try
@@ -57,17 +54,16 @@ int main(int argc, char **argv, char **env)
 	
 	mimes.setDefault();
 
-	signal(SIGINT, signalHandler);
-
 	Server serv = Server();
-	try
-	{
+	try {
 		serv.init_connection();
 	} catch (const std::exception &e) {
 		std::cerr << "Can't launch server!" << std::endl;
 		std::cerr << e.what() << std::endl;
 		return (1);
 	}
+
+	signal(SIGINT, signalHandler);
 
 	exit_code = 0;
 

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -7,7 +7,7 @@ MimeTypes mimes;
 int exit_code;
 
 /* throw a server exeption in case of failure */
-void process_request(int client_socket, char **env)
+void process_request(int client_socket, char **env, Server &serv)
 {
 	std::string req_raw_data;
 	char buffer[256];
@@ -24,9 +24,11 @@ void process_request(int client_socket, char **env)
 
 	Request req(client_socket, conf);
 	req.env = env;
-	Response res(client_socket, conf, req);
 
-	http_get_response(req, res);
+	Response *res = new Response(client_socket, conf, req);
+	http_get_response(req, *res);
+
+	serv.queue_response(res);
 }
 
 void signalHandler(int signum)
@@ -73,10 +75,9 @@ int main(int argc, char **argv, char **env)
 		struct epoll_event evlist[SIZE];
 		int nbr_req = epoll_wait(serv.get_poll_fd(), evlist, SIZE, 0);
 		for (int i = 0; i < nbr_req; ++i)
-		{
-			std::cout << "read from, fd: " << evlist[i].data.fd << std::endl;
-			process_request(evlist[i].data.fd, env);
-		}
+			process_request(evlist[i].data.fd, env, serv);
+
+		serv.handle_responses();
 	}
 
 	return (exit_code);

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -32,7 +32,7 @@ void process_request(int client_socket, char **env)
 void signalHandler(int signum)
 {
 	std::cout << std::endl
-			  << "Goodbye! That was cool top have you :)" << std::endl;
+			  << "Goodbye! That was cool to have you :)" << std::endl;
 
 	exit_code = signum;
 }

--- a/srcs/utils/string.cpp
+++ b/srcs/utils/string.cpp
@@ -16,3 +16,11 @@ std::string get_extension(std::string file_name)
     int position = file_name.find_last_of(".");
     return file_name.substr(position + 1);
 }
+
+std::string intToHex(int nb)
+{
+    std::stringstream stream;
+    stream << std::hex << nb;
+    std::string result(stream.str());
+    return result;
+}

--- a/srcs/utils/string.hpp
+++ b/srcs/utils/string.hpp
@@ -13,3 +13,4 @@ std::string to_string(T convert)
 
 std::string finish_by_only_one(std::string str, char c);
 std::string get_extension(std::string file_name);
+std::string intToHex(int nb);

--- a/srcs/webserv.hpp
+++ b/srcs/webserv.hpp
@@ -11,6 +11,7 @@
 #include "http_header/http_header.hpp"
 
 extern MimeTypes mimes;
+extern int exit_code;
 
 /* http */
 int http_get_response( Request &req, Response &res );


### PR DESCRIPTION
## Sommaire

Les éléments ajoutés par cette PR:
 - La **queues de réponses** aux requêtes
 - Lecture des **fichiers par stream**
 - Les **réponses par chunk** (block pour simplifier)
 - **Fermeture propre de la connexion** lors du téléchargement d'un gros fichier
   - *(lors d'un CTRL-C dans le terminal par exemple)*
 - Ajout de la **ré-utilisation du port** s'il est "ghost bind"
   - *(en gros plus besoin d'attendre 1min lorsque vous redémarrez votre serveur)*

### Resources utiles

Pour créer un fichier de 5Go (pour tester le téléchargement):
```bash
truncate -s 5M fichier_lourd.txt
```